### PR TITLE
feat(logger): add logger middleware

### DIFF
--- a/pkg/logger/middleware.go
+++ b/pkg/logger/middleware.go
@@ -1,0 +1,67 @@
+package logger
+
+import (
+	"strings"
+	"time"
+
+	"github.com/gofrs/uuid"
+	"github.com/labstack/echo"
+	"github.com/lob/logger-go"
+	"github.com/pkg/errors"
+)
+
+const key = "logger"
+
+func Middleware() func(next echo.HandlerFunc) echo.HandlerFunc {
+	l := logger.New()
+
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			t1 := time.Now()
+
+			id, err := uuid.NewV4()
+			if err != nil {
+				return errors.WithStack(err)
+			}
+
+			log := l.ID(id.String())
+			c.Set(key, log)
+
+			if err := next(c); err != nil {
+				c.Error(err)
+			}
+
+			t2 := time.Now()
+
+			var ipAddress string
+			if xff := c.Request().Header.Get("x-forwarded-for"); xff != "" {
+				split := strings.Split(xff, ",")
+				ipAddress = strings.TrimSpace(split[len(split)-1])
+			} else {
+				ipAddress = c.Request().RemoteAddr
+			}
+
+			log.Root(logger.Data{
+				"status_code":   c.Response().Status,
+				"method":        c.Request().Method,
+				"path":          c.Request().URL.Path,
+				"route":         c.Path(),
+				"response_time": t2.Sub(t1).Seconds() * 1000,
+				"referer":       c.Request().Referer(),
+				"user_agent":    c.Request().UserAgent(),
+				"ip_address":    ipAddress,
+				"trace_id":      c.Request().Header.Get("x-amzn-trace-id"),
+			}).Info("request handled")
+
+			return nil
+		}
+	}
+}
+
+func FromContext(c echo.Context) logger.Logger {
+	if log, ok := c.Get(key).(logger.Logger); ok {
+		return log
+	}
+
+	return logger.New()
+}

--- a/pkg/logger/middleware_test.go
+++ b/pkg/logger/middleware_test.go
@@ -1,0 +1,44 @@
+package logger
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/harrisonlob/goyagi/internal/test"
+	"github.com/labstack/echo"
+	"github.com/lob/logger-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMiddleware(t *testing.T) {
+	e := echo.New()
+	e.Use(Middleware())
+
+	e.GET("/", func(c echo.Context) error {
+		log, ok := c.Get("logger").(logger.Logger)
+		assert.True(t, ok, "expected logger to be of type Logger")
+		assert.NotNil(t, log)
+		return nil
+	})
+
+	req, err := http.NewRequest("GET", "/", nil)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+
+	e.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestFromContext(t *testing.T) {
+	log := logger.New()
+	c, _ := test.NewContext(t, nil, echo.MIMEApplicationJSON)
+	c.Set(key, log)
+
+	l := FromContext(c)
+
+	assert.Equal(t, log, l)
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -23,6 +23,8 @@ func New(app application.App) *http.Server {
 	b := binder.New()
 	e.Binder = b
 
+	e.Use(logger.Middleware())
+
 	health.RegisterRoutes(e)
 	movies.RegisterRoutes(e, app)
 


### PR DESCRIPTION
note: I add `-v2` to the branch name as I was doing some rebasing and I wanted to just make sure if I didn't do the rebase correctly I had an easy way to revert back to other pre rebase branch which was just name `add-logger`